### PR TITLE
docs: update demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - Firestore example
 - Typescript, PWA, Web Component support
 
-## [Demo](https://antoine92190.github.io/vue-advanced-chat)
+## [Demo](https://advanced-chat.github.io/vue-advanced-chat)
 
 Enjoy :smile:
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

The current demo link is broken, updates the link to https://advanced-chat.github.io/vue-advanced-chat/

We also need to update the link in the repository's About section.