### PR TITLE
Fix #435 

### DIFF
--- a/src/lib/Room/Room.scss
+++ b/src/lib/Room/Room.scss
@@ -1,6 +1,6 @@
 .vac-col-messages {
 	position: relative;
-	height: 100%;
+	height: 100svh;
 	flex: 1;
 	overflow: hidden;
 	display: flex;


### PR DESCRIPTION
Use svh instead of % to ensure that chat bar is not covered by browser bar in safari

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

<img width="515" alt="image" src="https://github.com/advanced-chat/vue-advanced-chat/assets/15629592/6147bc6f-014e-402c-b3bf-af70a6ca51eb">

