### PR TITLE
fix: load more rooms when less than minimumVisibleRooms and prepare build to support install from GitHub

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,8 +1,8 @@
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-  - - "@semantic-release/npm"
-    - npmPublish: true
+#  - - "@semantic-release/npm"
+#    - npmPublish: true
   - - "@semantic-release/changelog"
     - changelogFile: "CHANGELOG.md"
   - - "@semantic-release/github"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
 		"lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
 		"reset": "rm -rf node_modules && rm -rf package-lock.json && npm i",
 		"reset-all": "cd demo && npm run reset-all",
-		"pull-master": "git pull origin master --no-edit --no-ff"
+		"pull-main": "git pull origin main --no-edit --no-ff",
+        "prepare": "npm run build"
 	},
 	"typings": "types/index.d.ts",
 	"files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vue-advanced-chat",
-	"version": "2.0.9",
+	"version": "2.1.2",
 	"license": "MIT",
 	"description": "A beautiful chat rooms component made with Vue.js - compatible with Vue, React & Angular",
 	"author": {

--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -160,7 +160,6 @@ export default {
         // visible, automatically load more until either the list is "full"
         // or roomsLoaded becomes true.
         if (!this.loadingMoreRooms && visibleRooms.length < this.minimumVisibleRooms) {
-          this.loadingMoreRooms = true
           this.loadMoreRooms()
         }
       }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

This fixes a bug introduced in https://github.com/advanced-chat/vue-advanced-chat/commit/518697f4d9487c0bc139fa89dfbdc99f5636642d#r172487434

See https://github.com/advanced-chat/vue-advanced-chat/issues/566#issuecomment-3637016175

It also adds a prepare script to support installing from GitHub while we work to fix the publish to NPM CI process.

See https://blog.jim-nielsen.com/2018/installing-and-building-an-npm-package-from-github/
