### PR TITLE
Publish src/ for bundler consumers extending ChatWindow

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
 	"module": "./dist/vue-advanced-chat.es.js",
 	"unpkg": "./dist/vue-advanced-chat.umd.js",
 	"jsdelivr": "./dist/vue-advanced-chat.umd.js",
+	"exports": {
+		".": {
+			"import": "./dist/vue-advanced-chat.es.js",
+			"require": "./dist/vue-advanced-chat.umd.js",
+			"types": "./types/index.d.ts"
+		},
+		"./src/*": "./src/*"
+	},
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",
@@ -44,7 +52,8 @@
 	"typings": "types/index.d.ts",
 	"files": [
 		"dist/*",
-		"types/*"
+		"types/*",
+		"src/**/*"
 	],
 	"devDependencies": {
 		"@babel/core": "7.12.16",


### PR DESCRIPTION
## Summary

- Include `src/` in the published npm package (`files` field).
- Add a `./src/*` subpath export so Vite/Webpack consumers can import SFCs and SCSS when extending `ChatWindow.vue` via Vue `extends`, without vendoring or git-cloning the repo.

## Motivation

The default npm tarball only ships `dist/` and `types/`. Apps that extend upstream components (rather than using the web component entrypoint alone) need access to source SFCs and styles. We hit this integrating vue-advanced-chat into a Frappe desk bundle with a custom message footer.

No runtime/component behavior changes in this PR — packaging only.

## Test plan

- [ ] `npm pack` includes `src/lib/ChatWindow.vue` and `src/styles/index.scss`
- [ ] Existing `import { register } from 'vue-advanced-chat'` consumers unchanged
- [ ] Bundler can resolve `vue-advanced-chat/src/lib/ChatWindow.vue`


Made with [Cursor](https://cursor.com)