### PR TITLE
docs: brand the Storybook manager

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -19,6 +19,8 @@ const config: StorybookConfig = {
       },
     },
   },
+  managerHead: (head) =>
+    `${head ?? ''}\n<script>document.title = 'Advanced Chat Components'</script>`,
   viteFinal: async (config) =>
     mergeConfig(config, {
       // Honored by GitHub Pages deploy where the site lives under


### PR DESCRIPTION
## Summary

Replace Storybook's generic runtime browser title with `Advanced Chat Components` so the public Pages deployment is branded consistently with the package and repository.

## Validation

- `npm run build-storybook`
- generated manager contains the title override
- focused Storybook interaction and accessibility test
- `npm run type-check`
- `npm run lint`
- Prettier