### PR TITLE
release: prepare 3.0.0-rc.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
     id: package-version
     attributes:
       label: Package version
-      placeholder: 3.0.0-rc.1
+      placeholder: 3.0.0-rc.2
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and the project follows [Semantic Versioning](https://semver.org/).
 
 Only `3.0.0-alpha.0` was published to npm. The alpha.1 through alpha.5
 sections below are retained as internal development milestones that were folded
-into the first public release candidate.
+into the first public release candidate. The `v3.0.0-rc.1` tag failed
+pre-publish verification and was never published; rc.2 supersedes it.
 
-## 3.0.0-rc.1 - 2026-08-08
+## 3.0.0-rc.2 - 2026-08-08
 
 ### Added
 
@@ -62,7 +63,7 @@ into the first public release candidate.
   object URLs to the host. The library still revokes URLs for files removed or
   reset while pending; after emission the host must revoke them.
 - V3 compatibility records now distinguish stable `vue-advanced-chat@2.1.2`
-  from the pre-GA `@advanced-chat/components@3.0.0-rc.1` tree and record the
+  from the pre-GA `@advanced-chat/components@3.0.0-rc.2` tree and record the
   deliberate removal of audio recording, room ordering, template
   autocomplete, and the extra composer action.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains the release-candidate line of Advanced Chat
 Components:
 
 - **V3 release candidate** — published as
-  `@advanced-chat/components@3.0.0-rc.1` on the npm `next` tag. It contains 28
+  `@advanced-chat/components@3.0.0-rc.2` on the npm `next` tag. It contains 28
   typed Vue 3 SFCs plus an official light-DOM web-component entrypoint. The
   package is ESM-only; a browser-only UMD artifact remains available through
   the CDN metadata.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ This document defines the release path for V3 on the default `main` branch.
 
 The release tracks are intentionally separate: `vue-advanced-chat@2.1.2` is the
 stable v2 package, while this tree is the pre-GA
-`@advanced-chat/components@3.0.0-rc.1` line. Do not describe a release candidate
+`@advanced-chat/components@3.0.0-rc.2` line. Do not describe a release candidate
 as the stable replacement or modify the separate `vue-advanced-chat` package's
 `latest` tag as part of a V3 prerelease.
 
@@ -34,7 +34,7 @@ After trusted publishing is working:
 ## Release Preconditions
 
 - merge only reviewed, green commits into `main`
-- ensure `package.json` version already matches the intended tag, for example `3.0.0-rc.1`
+- ensure `package.json` version already matches the intended tag, for example `3.0.0-rc.2`
 - ensure the local and CI runtime meets npm trusted publishing minimums:
   - Node `22.14.0` or newer
   - npm `11.5.1` or newer
@@ -63,8 +63,8 @@ npm run verify:pack
 
 ## Version And Tag Rules
 
-- V3 prereleases use SemVer prerelease versions such as `3.0.0-rc.1`
-- the Git tag must match `package.json` exactly with a `v` prefix, for example `v3.0.0-rc.1`
+- V3 prereleases use SemVer prerelease versions such as `3.0.0-rc.2`
+- the Git tag must match `package.json` exactly with a `v` prefix, for example `v3.0.0-rc.2`
 - the release workflow publishes from immutable tags only; do not publish from a branch tip
 - prerelease tags publish to npm `next`; stable tags publish to npm `latest`
 
@@ -74,7 +74,7 @@ npm run verify:pack
    the reviewed change on `main`.
 2. Verify the exact release commit locally with `npm ci`, `npm run verify`, and `npm run verify:pack`.
 3. Create and push only the exact tag, for example
-   `git tag v3.0.0-rc.1 && git push origin v3.0.0-rc.1`.
+   `git tag v3.0.0-rc.2 && git push origin v3.0.0-rc.2`.
 4. The tag push starts `Release Package`; the workflow validates the tag and
    derives the npm dist-tag from the package version.
 5. Confirm the workflow completed successfully and that the published npm

--- a/docs/00-introduction.mdx
+++ b/docs/00-introduction.mdx
@@ -16,7 +16,7 @@ framework-independent hosts. Slots, theming, and TypeScript ergonomics
 no longer depend on Shadow DOM.
 
 The public stable line remains `vue-advanced-chat@2.1.2`. These docs describe
-`@advanced-chat/components@3.0.0-rc.1`, a pre-GA V3 release candidate. Do not
+`@advanced-chat/components@3.0.0-rc.2`, a pre-GA V3 release candidate. Do not
 treat the V3 API as the stable v2 package or as a drop-in upgrade.
 
 [v2]: https://github.com/advanced-chat/advanced-chat-components/tree/v2

--- a/docs/07-migration-from-v2.mdx
+++ b/docs/07-migration-from-v2.mdx
@@ -10,7 +10,7 @@ migration map; release-specific changes remain recorded in the `CHANGELOG.md`
 from the same source revision.
 
 The stable public line is `vue-advanced-chat@2.1.2`. These docs describe
-`@advanced-chat/components@3.0.0-rc.1`, a pre-GA V3 release candidate.
+`@advanced-chat/components@3.0.0-rc.2`, a pre-GA V3 release candidate.
 Migration is a deliberate package and API cutover, not an in-place dependency
 upgrade. Until GA, install the V3 package from its prerelease dist-tag:
 `npm install @advanced-chat/components@next`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@advanced-chat/components",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@advanced-chat/components",
-      "version": "3.0.0-rc.1",
+      "version": "3.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@vueuse/components": "^14.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advanced-chat/components",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "license": "MIT",
   "description": "Framework-neutral chat web component and typed Vue 3 component library",
   "contributors": [

--- a/rewrite/README.md
+++ b/rewrite/README.md
@@ -3,7 +3,7 @@
 This directory holds planning, historical audits, and the current compatibility
 record for the V3 rewrite of `vue-advanced-chat`. Stable v2 is
 `vue-advanced-chat@2.1.2`; the current pre-GA line is
-`@advanced-chat/components@3.0.0-rc.1`.
+`@advanced-chat/components@3.0.0-rc.2`.
 
 The library on the legacy `v2` branch ships v2 as a single web component registered via
 `register()`. V3 ships 28 individually importable typed Vue 3 components and a
@@ -30,7 +30,7 @@ remaining limits rather than treating every v2 difference as a regression.
   bucketed by whether the rewrite resolves them, still needs work,
   is intentionally out of scope, or warrants a stale-close.
 - [`release-plan.md`](./release-plan.md) — concrete path from the
-  current `3.0.0-rc.1` tree to a published `3.0.0` on npm,
+  current `3.0.0-rc.2` tree to a published `3.0.0` on npm,
   including version bumps, migration notes, and announcement plan.
 - [`publish-readiness-audit.md`](./publish-readiness-audit.md) — historical
   publication audit, resolution record, and remaining external release gates.

--- a/rewrite/architecture-review.md
+++ b/rewrite/architecture-review.md
@@ -2,7 +2,7 @@
 
 > Historical audit only. This review records the state and recommendations at
 > `3.0.0-alpha.1`; its words such as "today", "current", "missing", and
-> "incomplete" do not describe the `3.0.0-rc.1` working tree. Pagination,
+> "incomplete" do not describe the `3.0.0-rc.2` working tree. Pagination,
 > auto-scroll, event renames, action constants, type exports, Tailwind removal,
 > click-outside replacement, strict utility typing, and the public composables
 > subsequently landed. Use [`parity-checklist.md`](./parity-checklist.md) for

--- a/rewrite/architecture.md
+++ b/rewrite/architecture.md
@@ -6,7 +6,7 @@ exposes.
 
 ## What V3 changes vs v2
 
-| Concern       | v2 (`v2`, stable 2.1.2)                     | V3 (`main`, pre-GA 3.0.0-rc.1)                                          |
+| Concern       | v2 (`v2`, stable 2.1.2)                     | V3 (`main`, pre-GA 3.0.0-rc.2)                                          |
 | ------------- | ------------------------------------------- | ----------------------------------------------------------------------- |
 | Package name  | `vue-advanced-chat`                         | `@advanced-chat/components`                                             |
 | Distribution  | Single web component, explicit `register()` | 28 typed Vue SFCs plus bundled auto-registering web component           |

--- a/rewrite/ergonomics-review.md
+++ b/rewrite/ergonomics-review.md
@@ -7,7 +7,7 @@
 > shape, event payload normalization, chat slot names, text-formatting pass,
 > and locale negotiation described below subsequently changed. Use
 > [`parity-checklist.md`](./parity-checklist.md) and the public migration guide
-> for the `3.0.0-rc.1` contract.
+> for the `3.0.0-rc.2` contract.
 
 A consumer-facing review of the V3 surface at `3.0.0-alpha.1` —
 companion to `architecture-review.md` (which focused on structure).

--- a/rewrite/issue-triage.md
+++ b/rewrite/issue-triage.md
@@ -2,7 +2,7 @@
 
 Open issues and PRs on advanced-chat/advanced-chat-components, sorted by
 what V3 should do with each. Use this as the script for the post-3.0
-issue sweep. Last reconciled against the `3.0.0-rc.1` working tree.
+issue sweep. Last reconciled against the `3.0.0-rc.2` working tree.
 
 ## Resolved by V3 architecture (close on release)
 
@@ -56,10 +56,10 @@ notes and the version that shipped each fix.
 | Local search filter on `Chats`                                                                                        | `alpha.1`                            | `useLocalSearch` (extracted in `alpha.4`); `customSearchEnabled` opts out                                                             |
 | `chat-action-handler` re-emit on `Chats`                                                                              | `alpha.1`                            | `Chats` re-emits `ChatsItem`'s `chat-action-handler`                                                                                  |
 | Markdown task-list a11y warning                                                                                       | `alpha.1`                            | `aria-label` on `<input type="checkbox">` in markdown render                                                                          |
-| [#573](https://github.com/advanced-chat/advanced-chat-components/issues/573) Narrow embedded layout                   | `3.0.0-rc.1`                         | `AdvancedChat` observes its own width for the 768 px pane switch; message cards use `max-width: min(100%, 560px)`                     |
-| Audio playback state and controls                                                                                     | `3.0.0-rc.1`                         | Native play/pause/end synchronization, rejected-play handling, mouse/keyboard scrubbing, source/selection reset, and listener cleanup |
-| Mention payloads                                                                                                      | `3.0.0-rc.1`                         | Stable `<@id>` content plus deduplicated `mentionedUsers` on send/edit                                                                |
-| Host operational states                                                                                               | `3.0.0-rc.1`                         | Blocking and non-blocking state UI, retry event, and independently disabled composer                                                  |
+| [#573](https://github.com/advanced-chat/advanced-chat-components/issues/573) Narrow embedded layout                   | `3.0.0-rc.2`                         | `AdvancedChat` observes its own width for the 768 px pane switch; message cards use `max-width: min(100%, 560px)`                     |
+| Audio playback state and controls                                                                                     | `3.0.0-rc.2`                         | Native play/pause/end synchronization, rejected-play handling, mouse/keyboard scrubbing, source/selection reset, and listener cleanup |
+| Mention payloads                                                                                                      | `3.0.0-rc.2`                         | Stable `<@id>` content plus deduplicated `mentionedUsers` on send/edit                                                                |
+| Host operational states                                                                                               | `3.0.0-rc.2`                         | Blocking and non-blocking state UI, retry event, and independently disabled composer                                                  |
 
 ## Compatibility decisions before beta
 

--- a/rewrite/parity-checklist.md
+++ b/rewrite/parity-checklist.md
@@ -1,7 +1,7 @@
 # V2 -> V3 Compatibility Record
 
 Current compatibility status for stable `vue-advanced-chat@2.1.2` and the
-pre-GA `@advanced-chat/components@3.0.0-rc.1` working tree. Unlike the
+pre-GA `@advanced-chat/components@3.0.0-rc.2` working tree. Unlike the
 archived alpha.1 reviews, this file is maintained as the current source of
 truth.
 
@@ -17,7 +17,7 @@ Status legend:
 
 | v2 surface                                   | V3 surface                                                 | Status  | Notes                                                                          |
 | -------------------------------------------- | ---------------------------------------------------------- | ------- | ------------------------------------------------------------------------------ |
-| Stable `vue-advanced-chat@2.1.2`             | Pre-GA `@advanced-chat/components@3.0.0-rc.1` tree         | Done    | Separate package and release track; not an in-place upgrade.                   |
+| Stable `vue-advanced-chat@2.1.2`             | Pre-GA `@advanced-chat/components@3.0.0-rc.2` tree         | Done    | Separate package and release track; not an in-place upgrade.                   |
 | One Shadow DOM custom element + `register()` | 28 typed Vue SFCs plus bundled light-DOM custom element    | Done    | Vue is primary; web-component entrypoint auto-registers by default.            |
 | JSON-stringified object/array props          | Typed Vue props or custom-element DOM properties           | Done    | Do not serialize complex V3 values into attributes.                            |
 | Web-component event payloads                 | Typed `CustomEvent.detail`                                 | Done    | V3 exposes the payload directly, without Vue's single-argument array wrapper.  |

--- a/rewrite/publish-readiness-audit.md
+++ b/rewrite/publish-readiness-audit.md
@@ -18,13 +18,13 @@ implementation.
 
 ## Resolution status
 
-The `3.0.0-rc.1` preparation resolved the codebase and documentation blockers
+The `3.0.0-rc.2` preparation resolved the codebase and documentation blockers
 recorded below:
 
 - The repository was renamed to `advanced-chat/advanced-chat-components`, its
   Pages URL exists, repository metadata is current, and private vulnerability
   reporting is enabled.
-- The package is versioned `3.0.0-rc.1`; prereleases publish to npm `next` from
+- The package is versioned `3.0.0-rc.2`; prereleases publish to npm `next` from
   immutable tag pushes.
 - The Node package is ESM-only. Browser UMD remains CDN-only and is not exposed
   through a CommonJS condition.
@@ -39,7 +39,7 @@ recorded below:
 
 Remaining external gates are operational rather than source defects: merge the
 release commit to the default branch, deploy and verify the Storybook Pages
-site, confirm npm trusted publishing, publish `v3.0.0-rc.1` to `next`, and verify
+site, confirm npm trusted publishing, publish `v3.0.0-rc.2` to `next`, and verify
 the installed package and provenance anonymously.
 
 ## Original publication blockers (resolved)
@@ -171,11 +171,11 @@ the bundle dependency set changes.
   asides, test-count snapshots, and rewrite-directory bookkeeping from public
   changelog entries unless they explain consumer impact.
 
-## Decisions resolved during rc.1 preparation
+## Decisions resolved during release-candidate preparation
 
 1. Repository: `advanced-chat/advanced-chat-components`; V3 becomes the default
    `main` line and legacy source is preserved on `v2`.
-2. Version: `3.0.0-rc.1`; prereleases publish to `next`, stable to `latest`.
+2. Version: `3.0.0-rc.2`; prereleases publish to `next`, stable to `latest`.
 3. Module policy: ESM-only Node package with a browser-only UMD artifact.
 4. TypeScript policy: strict `Bundler` and `NodeNext` consumers are verified.
 5. CDN policy: browser UMD remains the Vue-library CDN artifact; the standalone
@@ -205,5 +205,5 @@ the bundle dependency set changes.
 
 Publication is complete only when the final commit and workflows are on `main`,
 the Pages site serves the V3 Storybook build, npm trusted publishing succeeds
-for `v3.0.0-rc.1`, `next` resolves to that version, provenance is visible, and a
+for `v3.0.0-rc.2`, `next` resolves to that version, provenance is visible, and a
 clean anonymous consumer can install and exercise the documented entrypoints.

--- a/rewrite/release-plan.md
+++ b/rewrite/release-plan.md
@@ -1,6 +1,6 @@
 # V3 Release Plan
 
-This is the path from `@advanced-chat/components@3.0.0-rc.1` to a published
+This is the path from `@advanced-chat/components@3.0.0-rc.2` to a published
 `3.0.0`. Stable v2 remains `vue-advanced-chat@2.1.2` on npm and its source is
 preserved on the `v2` branch; V3 is not a drop-in replacement.
 
@@ -21,11 +21,11 @@ preserved on the `v2` branch; V3 is not a drop-in replacement.
 ## Publication baseline
 
 The 2026-08-08 [publish-readiness audit](./publish-readiness-audit.md) found
-release blockers not covered by the original build and test gates. The rc.1
+release blockers not covered by the original build and test gates. The rc.2
 preparation resolved the repository identity, version, CommonJS, licensing,
 declaration, manifest, governance, public-copy, and packed-consumer findings.
 The remaining gates are external: merge to the default branch, deploy and
-verify Pages, confirm npm trusted publishing, and publish the immutable rc.1
+verify Pages, confirm npm trusted publishing, and publish the immutable rc.2
 tag to `next`.
 
 ## Gates that must be green before tagging
@@ -104,7 +104,7 @@ onSend?, onReceive? }`) — defaults match the alpha.2 hard-coded
      Currently still resolves to `'en'` (only locale shipped) but
      warns in DEV when the detected language isn't supported, so
      adding a second locale is purely additive.
-6. **Post-alpha.5 public-contract fixes** ✅ included in `3.0.0-rc.1`:
+6. **Post-alpha.5 public-contract fixes** ✅ included in `3.0.0-rc.2`:
    - Typed, auto-registering light-DOM web-component entrypoint with direct
      `CustomEvent.detail` and future-mount registration option semantics.
    - Stable `<@id>` mention content plus `mentionedUsers` on send/edit.
@@ -127,7 +127,7 @@ onSend?, onReceive? }`) — defaults match the alpha.2 hard-coded
        does (`backfillIfBelowMinimum`) so the file reads as a single
        codepath.
 
-8. **Release-candidate prep** ✅ completed for `3.0.0-rc.1`:
+8. **Release-candidate prep** ✅ completed for `3.0.0-rc.2`:
    - ESM-only package contract and strict packed-consumer verification.
    - MIT and bundled third-party notices.
    - Security, contribution, conduct, support, and issue templates.
@@ -154,13 +154,15 @@ Use semver prereleases on `next`:
 - `3.0.0-alpha.5` — internal milestone closing the originally listed GA gaps:
   file-constraint props, typing-indicator position, `autoScroll`
   policy, locale negotiation, slot autodocs.
-- `3.0.0-rc.1` — first public release candidate: contract complete, ESM-only,
-  licensed, packed-consumer verified, and documentation audited.
+- `3.0.0-rc.1` — failed pre-publish verification; immutable tag retained but no
+  npm package was published.
+- `3.0.0-rc.2` — first published release candidate: contract complete,
+  ESM-only, licensed, packed-consumer verified, and documentation audited.
 - `3.0.0` — promoted to `latest`
 
 Each tag must satisfy:
 
-- `package.json` version matches the tag (`v3.0.0-rc.1` ↔ `3.0.0-rc.1`)
+- `package.json` version matches the tag (`v3.0.0-rc.2` ↔ `3.0.0-rc.2`)
 - Tag is pushed from a clean, reviewed commit on `main`
 - CI on the exact tag is green
 
@@ -171,7 +173,7 @@ Triggered by an immutable `v*` tag push:
 1. Ensure `package.json` and the changelog match the intended version on
    `main`.
 2. Tag and push only that tag, for example
-   `git tag v3.0.0-rc.1 && git push origin v3.0.0-rc.1`.
+   `git tag v3.0.0-rc.2 && git push origin v3.0.0-rc.2`.
 3. The workflow validates the tag and publishes prereleases to `next` or stable
    versions to `latest`.
 4. Confirm the npm package page shows provenance on the new version.

--- a/src/components/AdvancedChat.stories.ts
+++ b/src/components/AdvancedChat.stories.ts
@@ -286,6 +286,10 @@ export const ReplyActionPrefillsFooter: Story = {
     await waitFor(() => {
       expect(canvasElement.querySelector('.acc-footer-reply-wrapper')).toBeTruthy()
     })
+    await waitFor(() => {
+      expect(canvasElement.querySelector('.acc-menu-item')).toBeNull()
+      expect(canvasElement.querySelector('.acc-menu-options')).toBeNull()
+    })
   },
 }
 
@@ -335,6 +339,10 @@ export const HeaderMenuActionFires: Story = {
     const item = canvasElement.querySelector('.acc-menu-item') as HTMLElement
     await userEvent.click(item)
     await expect(args['onMenu-action-handler']).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(canvasElement.querySelector('.acc-menu-item')).toBeNull()
+      expect(canvasElement.querySelector('.acc-menu-options')).toBeNull()
+    })
   },
 }
 
@@ -366,6 +374,10 @@ export const ChatActionHandlerEmits: Story = {
     const action = canvasElement.querySelector('.acc-menu-item') as HTMLElement
     await userEvent.click(action)
     await expect(args['onChat-action-handler']).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(canvasElement.querySelector('.acc-menu-item')).toBeNull()
+      expect(canvasElement.querySelector('.acc-menu-options')).toBeNull()
+    })
   },
 }
 

--- a/src/components/Chat.stories.ts
+++ b/src/components/Chat.stories.ts
@@ -108,6 +108,10 @@ export const ReplyActionPrefillsFooter: Story = {
     await waitFor(() => {
       expect(canvasElement.querySelector('.acc-footer-reply-wrapper')).toBeTruthy()
     })
+    await waitFor(() => {
+      expect(canvasElement.querySelector('.acc-menu-item')).toBeNull()
+      expect(canvasElement.querySelector('.acc-menu-options')).toBeNull()
+    })
   },
 }
 
@@ -132,6 +136,10 @@ export const EditActionPrefillsFooter: Story = {
     await userEvent.click(edit)
     await waitFor(() => {
       expect(canvasElement.querySelector('.acc-textarea-outline')).toBeTruthy()
+    })
+    await waitFor(() => {
+      expect(canvasElement.querySelector('.acc-menu-item')).toBeNull()
+      expect(canvasElement.querySelector('.acc-menu-options')).toBeNull()
     })
   },
 }

--- a/src/components/ChatHeader.stories.ts
+++ b/src/components/ChatHeader.stories.ts
@@ -83,6 +83,10 @@ export const MenuActionHandler: Story = {
         action: { id: 'archive', label: 'Archive' },
       }),
     )
+    await waitFor(() => {
+      expect(canvasElement.querySelector('.acc-menu-item')).toBeNull()
+      expect(canvasElement.querySelector('.acc-menu-options')).toBeNull()
+    })
   },
 }
 

--- a/src/components/Chats.stories.ts
+++ b/src/components/Chats.stories.ts
@@ -150,6 +150,10 @@ export const ChatActionHandlerEmits: Story = {
     const action = canvasElement.querySelector('.acc-menu-item') as HTMLElement
     await userEvent.click(action)
     await expect(args['onChat-action-handler']).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(canvasElement.querySelector('.acc-menu-item')).toBeNull()
+      expect(canvasElement.querySelector('.acc-menu-options')).toBeNull()
+    })
   },
 }
 

--- a/src/components/ChatsItem.stories.ts
+++ b/src/components/ChatsItem.stories.ts
@@ -60,6 +60,7 @@ export const ActionHandlerEmits: Story = {
     )
     await waitFor(() => {
       expect(canvasElement.querySelector('.acc-menu-item')).toBeNull()
+      expect(canvasElement.querySelector('.acc-menu-options')).toBeNull()
     })
   },
 }

--- a/src/components/Message.stories.ts
+++ b/src/components/Message.stories.ts
@@ -129,6 +129,9 @@ export const ReactionPickerEmits: Story = {
     const firstReaction = canvasElement.querySelector('.acc-reaction-option') as HTMLElement
     await userEvent.click(firstReaction)
     await expect(args['onSend-message-reaction']).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(canvasElement.querySelector('.acc-reactions-menu')).toBeNull()
+    })
   },
 }
 
@@ -149,6 +152,10 @@ export const DropdownActionEmits: Story = {
     const firstAction = canvasElement.querySelector('.acc-menu-item') as HTMLElement
     await userEvent.click(firstAction)
     await expect(args['onMessage-action-handler']).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(canvasElement.querySelector('.acc-menu-item')).toBeNull()
+      expect(canvasElement.querySelector('.acc-menu-options')).toBeNull()
+    })
   },
 }
 

--- a/src/components/MessageActions.stories.ts
+++ b/src/components/MessageActions.stories.ts
@@ -106,6 +106,10 @@ export const DropdownMenuOpen: Story = {
     })
     await waitFor(() => expect(trigger).toHaveFocus())
     expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await waitFor(() => {
+      expect(canvasElement.querySelector('.acc-menu-item')).toBeNull()
+      expect(canvas.queryByRole('menu', { name: 'Message actions' })).not.toBeInTheDocument()
+    })
   },
 }
 


### PR DESCRIPTION
## Summary

- bump the corrective release candidate to `3.0.0-rc.2` after rc.1 failed verification before npm publication
- record rc.1 as an immutable failed pre-publish tag and synchronize all current release/documentation references
- make every action-menu interaction wait for its leave transition to finish before Storybook's post-play accessibility scan

## Validation

- affected 11 Storybook interaction/a11y stories passed twice through Storybook MCP
- full package Storybook suite passed three consecutive runs (214/214 each)
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm run verify`
- packed ESM, Vite, Bundler, NodeNext, SSR, CSS, license, manifest, and Chromium web-component checks

The `v3.0.0-rc.1` workflow stopped before `npm publish`; npm still contains only alpha.0.